### PR TITLE
Fixed Carousel Images in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,20 @@
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
   </head>
+  <style> 
+        * {
+           margin: 0;
+           padding: 0; 
+        }
+        #img1 {
+            margin: 0 auto;
+            min-width: 100%;
+        }
+        #img2 {
+            max-width: 100%;
+            margin: 0 auto;
+        }
+    </style>
   <body>
   		<nav class="navbar navbar-inverse" role="navigation">
                 <div class="container">


### PR DESCRIPTION
For both images, I set: 

margin: 0 auto;

For most images, I think we should set min-width to be 100%; however, because the Optimir logo was significantly smaller than the Cal @ Night photo, with a min-width of 100%, the picture resolution diminished greatly. So I set the max-width: 100%. Now both pictures are centered and conform well to the size of the page. 
