### PR TITLE
Add gitignore, ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This file tells git to ignore files that match regexes. Each regex goes on a separate line. For now, we just want to ignore the .DS_Store files that Macs use.
